### PR TITLE
AXML interator

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -133,6 +133,39 @@ impl Axml {
     }
 }
 
+pub struct AxmlIterator {
+    /// Stack of nodes for depth-first traversal
+    stack: Vec<XmlNode>,
+}
+
+// Consuming iterators
+impl IntoIterator for Axml {
+    type Item = XmlNode;
+    type IntoIter = AxmlIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        AxmlIterator {
+            stack: vec![Rc::clone(&self.root)],
+        }
+    }
+}
+
+impl Iterator for AxmlIterator {
+    type Item = XmlNode;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.stack.pop() {
+            Some(node) => {
+                for child in &node.borrow().children {
+                    self.stack.push(Rc::clone(child));
+                }
+                Some(node)
+            },
+            None => None,
+        }
+    }
+}
+
 /// Parse the start of a namepace
 pub fn parse_start_namespace(axml_buff: &mut Cursor<Vec<u8>>,
                              strings: &[String],

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -80,8 +80,17 @@ impl XmlElement {
 
         Ok(())
     }
-}
 
+    /// Get the element's name off of its attributes if it exists
+    pub fn get_name(&self) -> Option<&String> {
+        self.attributes.get("android:name")
+    }
+
+    /// Get an attribute from an `XmlElement` if it exists
+    pub fn get_attr(&self, attr_name: &str) -> Option<&String> {
+        self.attributes.get(attr_name)
+    }
+}
 
 /// XML nodes
 pub type XmlNode = Rc<RefCell<XmlElement>>;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -131,6 +131,13 @@ impl Axml {
 
         Ok(result)
     }
+
+    /// Returns a non-consuming iterator over the AXML doc elements
+    pub fn iter(&self) -> AxmlIterator {
+        AxmlIterator {
+            stack: vec![Rc::clone(&self.root)]
+        }
+    }
 }
 
 pub struct AxmlIterator {
@@ -138,7 +145,6 @@ pub struct AxmlIterator {
     stack: Vec<XmlNode>,
 }
 
-// Consuming iterators
 impl IntoIterator for Axml {
     type Item = XmlNode;
     type IntoIter = AxmlIterator;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -140,6 +140,9 @@ impl Axml {
     }
 }
 
+/// Iterator over an AXML doc
+///
+/// Iterates through all of the parsed AXML doc elements using depth-first search
 pub struct AxmlIterator {
     /// Stack of nodes for depth-first traversal
     stack: Vec<XmlNode>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -49,6 +49,7 @@ pub struct XmlElement {
 }
 
 impl XmlElement {
+    /// Write an `XmlElement` into a writer
     fn write_element<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), Error> {
         let mut element = writer.create_element(&self.element_type);
 
@@ -93,6 +94,7 @@ pub struct Axml {
 }
 
 impl Axml {
+    /// Write the whole parsed XML to a file
     pub fn write_to_file(&self, file: &mut File) -> Result<(), Error> {
         match self.to_string() {
             Ok(str_xml) => {
@@ -104,6 +106,7 @@ impl Axml {
         }
     }
 
+    /// Convert the whole parsed XML into a string
     pub fn to_string(&self) -> Result<String, Error> {
         let mut writer = Writer::new_with_indent(Vec::new(), b' ', 4);
 


### PR DESCRIPTION
This PR adds a new struct `AxmlIterator` which implements `IntoIterator`. This allows a user to iterate through all of the AXML doc elements using depth-first search.