### PR TITLE
Better error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ cli = ["dep:clap"]
 byteorder = "1.4.3"
 clap = { version = "4.5.4", features = ["derive"], optional = true }
 quick-xml = "0.31.0"
+thiserror = "2.0.11"
 zip = "0.5"

--- a/src/bin/axmlparser/main.rs
+++ b/src/bin/axmlparser/main.rs
@@ -5,11 +5,12 @@ use std::fs::File;
 use rusty_axml::{
     create_cursor_from_apk,
     create_cursor_from_axml,
+    errors::AxmlError,
 };
 
 use crate::cli::ArgType;
 
-fn main() {
+fn main() -> Result<(), AxmlError> {
     // Check CLI arguments
     let args = cli::parse_args();
 
@@ -22,10 +23,10 @@ fn main() {
         ArgType::Apk  => { create_cursor_from_apk(&arg_path)  },
         ArgType::Axml => { create_cursor_from_axml(&arg_path) },
         _ => todo!()
-    };
+    }?;
 
     // Parse the XML
-    let axml = rusty_axml::parse_from_cursor(axml_cursor);
+    let axml = rusty_axml::parse_from_cursor(axml_cursor)?;
 
     // Write to file if `args::output` is not `None`
     match args.get_output_path() {
@@ -41,4 +42,6 @@ fn main() {
             };
         }
     }
+
+    Ok(())
 }

--- a/src/chunks/chunk_header.rs
+++ b/src/chunks/chunk_header.rs
@@ -38,8 +38,7 @@ impl ChunkHeader {
         let minimum_size = 8;
 
         // Get chunk type
-        let chunk_type = ChunkType::parse_block_type(axml_buff)
-                        .expect("Error: cannot parse block type");
+        let chunk_type = ChunkType::parse_block_type(axml_buff)?;
 
         // Check if this is indeed of the expected type
         if chunk_type != expected_type {

--- a/src/chunks/chunk_header.rs
+++ b/src/chunks/chunk_header.rs
@@ -4,17 +4,17 @@
 //! The header is rather small and only contain the type of the chunk (identified
 //! by the `ChunkType` enum), the header size, and the chunk size.
 
-use std::io::{
-    Error,
-    Cursor,
-};
+use std::io::Cursor;
 
 use byteorder::{
     LittleEndian,
     ReadBytesExt,
 };
 
-use crate::chunks::chunk_types::ChunkType;
+use crate::{
+    chunks::chunk_types::ChunkType,
+    errors::AxmlError
+};
 
 /// Header that appears at the beginning of every chunk
 #[derive(Debug)]
@@ -33,7 +33,7 @@ pub struct ChunkHeader {
 
 impl ChunkHeader {
     /// Parse bytes from given buffer into a `ChunkHeader`
-    pub fn from_buff(axml_buff: &mut Cursor<Vec<u8>>, expected_type: ChunkType) -> Result<Self, Error> {
+    pub fn from_buff(axml_buff: &mut Cursor<Vec<u8>>, expected_type: ChunkType) -> Result<Self, AxmlError> {
         // Minimum size, for a chunk with no data
         let minimum_size = 8;
 
@@ -47,8 +47,8 @@ impl ChunkHeader {
         }
 
         // Get chunk header size and total size
-        let header_size = axml_buff.read_u16::<LittleEndian>().unwrap();
-        let chunk_size = axml_buff.read_u32::<LittleEndian>().unwrap();
+        let header_size = axml_buff.read_u16::<LittleEndian>()?;
+        let chunk_size = axml_buff.read_u32::<LittleEndian>()?;
 
         // Exhaustive checks on the announced sizes
         if header_size < minimum_size {

--- a/src/chunks/chunk_types.rs
+++ b/src/chunks/chunk_types.rs
@@ -4,14 +4,13 @@
 //! along with helper methods to parse and display them.
 
 use std::fmt;
-use std::io::{
-    Error,
-    Cursor,
-};
+use std::io::Cursor;
 use byteorder::{
     LittleEndian,
     ReadBytesExt
 };
+
+use crate::errors::AxmlError;
 
 /* Type identifiers for chunks. Only includes the ones related to XML */
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -45,11 +44,8 @@ pub enum ChunkType {
 
 impl ChunkType {
     /// Attempt to parse the chunk type from a cursor of bytes
-    pub fn parse_block_type(buff: &mut Cursor<Vec<u8>>) -> Result<Self, Error> {
-        let raw_block_type = match buff.read_u16::<LittleEndian>() {
-            Ok(block) => block,
-            Err(e) => return Err(e),
-        };
+    pub fn parse_block_type(buff: &mut Cursor<Vec<u8>>) -> Result<Self, AxmlError> {
+        let raw_block_type = buff.read_u16::<LittleEndian>()?;
 
         let block_type = match raw_block_type {
             0x0000 => ChunkType::ResNullType,

--- a/src/chunks/res_table.rs
+++ b/src/chunks/res_table.rs
@@ -42,8 +42,7 @@ impl ResTable {
         axml_buff.set_position(initial_offset - 2);
 
         // Parse chunk header
-        let header = ChunkHeader::from_buff(axml_buff, ChunkType::ResTableType)
-                     .expect("Error: cannot get chunk header from string pool");
+        let header = ChunkHeader::from_buff(axml_buff, ChunkType::ResTableType)?;
 
         // Get package count
         let package_count = axml_buff.read_u32::<LittleEndian>()?;
@@ -52,15 +51,13 @@ impl ResTable {
 
         // TODO: these are just ignored
         for _ in 0..package_count {
-            let block_type = ChunkType::parse_block_type(axml_buff)
-                            .expect("Error: cannot parse block type");
+            let block_type = ChunkType::parse_block_type(axml_buff)?;
             match block_type {
                 ChunkType::ResStringPoolType => {
                     StringPool::from_buff(axml_buff, &mut strings)?;
                 },
                 ChunkType::ResTablePackageType => {
-                    ResTablePackage::parse(axml_buff)
-                                    .expect("Error: cannot parse table package");
+                    ResTablePackage::parse(axml_buff)?;
                 },
                 _ => { panic!("######## Unexpected block type: {:02X}", block_type); }
             };
@@ -120,8 +117,7 @@ impl ResTablePackage {
         axml_buff.set_position(initial_offset - 2);
 
         // Parse chunk header
-        let header = ChunkHeader::from_buff(axml_buff, ChunkType::ResTablePackageType)
-                     .expect("Error: cannot get chunk header for ResTablePackage");
+        let header = ChunkHeader::from_buff(axml_buff, ChunkType::ResTablePackageType)?;
 
         // Get other members
         let id = axml_buff.read_u32::<LittleEndian>()?;

--- a/src/chunks/res_table.rs
+++ b/src/chunks/res_table.rs
@@ -9,16 +9,16 @@
 //! Specific entries within a resource table can be uniquely identified
 //! with a single integer as defined by the ResTable_ref structure.
 
-use crate::chunks::{
-    chunk_header::ChunkHeader,
-    string_pool::StringPool,
-    chunk_types::ChunkType
+use crate::{
+    chunks::{
+        chunk_header::ChunkHeader,
+        chunk_types::ChunkType,
+        string_pool::StringPool
+    },
+    errors::AxmlError
 };
 
-use std::io::{
-    Error,
-    Cursor,
-};
+use std::io::Cursor;
 
 use byteorder::{
     LittleEndian,
@@ -36,25 +36,27 @@ pub struct ResTable {
 
 impl ResTable {
     /// Parse from a cursor of bytes
-    pub fn parse(axml_buff: &mut Cursor<Vec<u8>>) {
+    pub fn parse(axml_buff: &mut Cursor<Vec<u8>>) -> Result<Self, AxmlError> {
         // Go back 2 bytes, to account from the block type
         let initial_offset = axml_buff.position();
         axml_buff.set_position(initial_offset - 2);
 
         // Parse chunk header
-        let _header = ChunkHeader::from_buff(axml_buff, ChunkType::ResTableType)
+        let header = ChunkHeader::from_buff(axml_buff, ChunkType::ResTableType)
                      .expect("Error: cannot get chunk header from string pool");
 
         // Get package count
-        let package_count = axml_buff.read_u32::<LittleEndian>().unwrap();
+        let package_count = axml_buff.read_u32::<LittleEndian>()?;
 
         let mut strings = Vec::<String>::new();
+
+        // TODO: these are just ignored
         for _ in 0..package_count {
             let block_type = ChunkType::parse_block_type(axml_buff)
                             .expect("Error: cannot parse block type");
             match block_type {
                 ChunkType::ResStringPoolType => {
-                    StringPool::from_buff(axml_buff, &mut strings);
+                    StringPool::from_buff(axml_buff, &mut strings)?;
                 },
                 ChunkType::ResTablePackageType => {
                     ResTablePackage::parse(axml_buff)
@@ -63,6 +65,11 @@ impl ResTable {
                 _ => { panic!("######## Unexpected block type: {:02X}", block_type); }
             };
         }
+
+        Ok(Self {
+            header,
+            package_count
+        })
     }
 }
 
@@ -106,7 +113,7 @@ pub struct ResTablePackage {
 
 impl ResTablePackage {
     /// Parse from a cursor of bytes
-    pub fn parse(axml_buff: &mut Cursor<Vec<u8>>) -> Result<Self, Error> {
+    pub fn parse(axml_buff: &mut Cursor<Vec<u8>>) -> Result<Self, AxmlError> {
 
         // Go back 2 bytes, to account from the block type
         let initial_offset = axml_buff.position();
@@ -117,20 +124,20 @@ impl ResTablePackage {
                      .expect("Error: cannot get chunk header for ResTablePackage");
 
         // Get other members
-        let id = axml_buff.read_u32::<LittleEndian>().unwrap();
+        let id = axml_buff.read_u32::<LittleEndian>()?;
 
         let mut name: [u16; 128] = [0; 128];
         for i in 0..128 {
-            name[i] = axml_buff.read_u16::<LittleEndian>().unwrap();
+            name[i] = axml_buff.read_u16::<LittleEndian>()?;
             if name[i] == 0x00 {
                 break;
             }
         }
-        let type_strings = axml_buff.read_u32::<LittleEndian>().unwrap();
-        let last_public_type = axml_buff.read_u32::<LittleEndian>().unwrap();
-        let key_strings = axml_buff.read_u32::<LittleEndian>().unwrap();
-        let last_public_key = axml_buff.read_u32::<LittleEndian>().unwrap();
-        let type_id_offset = axml_buff.read_u32::<LittleEndian>().unwrap();
+        let type_strings = axml_buff.read_u32::<LittleEndian>()?;
+        let last_public_type = axml_buff.read_u32::<LittleEndian>()?;
+        let key_strings = axml_buff.read_u32::<LittleEndian>()?;
+        let last_public_key = axml_buff.read_u32::<LittleEndian>()?;
+        let type_id_offset = axml_buff.read_u32::<LittleEndian>()?;
 
         // Build and return the object
         Ok(ResTablePackage {

--- a/src/chunks/res_value.rs
+++ b/src/chunks/res_value.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code)]
 
-use crate::chunks::data_value_type::DataValueType;
-
-use std::io::{
-    Error,
-    Cursor,
+use crate::{
+    chunks::data_value_type::DataValueType,
+    errors::AxmlError
 };
+
+use std::io:: Cursor;
 use byteorder::{
     LittleEndian,
     ReadBytesExt
@@ -28,16 +28,16 @@ pub struct ResValue {
 
 impl ResValue {
     /// Parse from a cursor of bytes
-    pub fn from_buff(axml_buff: &mut Cursor<Vec<u8>>) -> Result<Self, Error> {
-        let size = axml_buff.read_u16::<LittleEndian>().unwrap();
-        let res0 = axml_buff.read_u8().unwrap();
+    pub fn from_buff(axml_buff: &mut Cursor<Vec<u8>>) -> Result<Self, AxmlError> {
+        let size = axml_buff.read_u16::<LittleEndian>()?;
+        let res0 = axml_buff.read_u8()?;
 
         if res0 != 0 {
             panic!("res0 is not 0");
         }
 
-        let data_type = DataValueType::from_val(axml_buff.read_u8().unwrap());
-        let data = axml_buff.read_u32::<LittleEndian>().unwrap();
+        let data_type = DataValueType::from_val(axml_buff.read_u8()?);
+        let data = axml_buff.read_u32::<LittleEndian>()?;
 
         Ok(ResValue {
             size,

--- a/src/chunks/resource_map.rs
+++ b/src/chunks/resource_map.rs
@@ -1362,15 +1362,14 @@ pub struct ResourceMap {
 impl ResourceMap {
     /// Parse a from a cursor of bytes
     pub fn from_buff(axml_buff: &mut Cursor<Vec<u8>>) -> Result<Self, AxmlError> {
-        /* Go back 2 bytes, to account from the block type */
+        // Go back 2 bytes, to account from the block type
         let offset = axml_buff.position();
         axml_buff.set_position(offset - 2);
 
-        /* Parse chunk header */
-        let header = ChunkHeader::from_buff(axml_buff, ChunkType::ResXmlResourceMapType)
-                     .expect("Error: cannot get chunk header from string pool");
+        // Parse chunk header
+        let header = ChunkHeader::from_buff(axml_buff, ChunkType::ResXmlResourceMapType)?;
 
-        /* Get resources IDs */
+        // Get resources IDs
         let mut resources_id = Vec::new();
         let nb_resources = (header.chunk_size / 4) - 2;
         for _ in 0..nb_resources {

--- a/src/chunks/resource_map.rs
+++ b/src/chunks/resource_map.rs
@@ -7,13 +7,11 @@
 
 use crate::chunks::{
     chunk_header::ChunkHeader,
-    chunk_types::ChunkType
+    chunk_types::ChunkType,
 };
+use crate::errors::AxmlError;
 
-use std::io::{
-    Error,
-    Cursor,
-};
+use std::io::Cursor;
 
 use byteorder::{
     LittleEndian,
@@ -1363,7 +1361,7 @@ pub struct ResourceMap {
 
 impl ResourceMap {
     /// Parse a from a cursor of bytes
-    pub fn from_buff(axml_buff: &mut Cursor<Vec<u8>>) -> Result<Self, Error> {
+    pub fn from_buff(axml_buff: &mut Cursor<Vec<u8>>) -> Result<Self, AxmlError> {
         /* Go back 2 bytes, to account from the block type */
         let offset = axml_buff.position();
         axml_buff.set_position(offset - 2);
@@ -1376,7 +1374,7 @@ impl ResourceMap {
         let mut resources_id = Vec::new();
         let nb_resources = (header.chunk_size / 4) - 2;
         for _ in 0..nb_resources {
-            let id = axml_buff.read_u32::<LittleEndian>().unwrap();
+            let id = axml_buff.read_u32::<LittleEndian>()?;
             resources_id.push(id);
         }
 

--- a/src/chunks/string_pool.rs
+++ b/src/chunks/string_pool.rs
@@ -98,8 +98,7 @@ impl StringPool {
         let initial_offset = initial_offset as u32;
 
         // Parse chunk header
-        let header = ChunkHeader::from_buff(axml_buff, ChunkType::ResStringPoolType)
-                     .expect("Error: cannot get chunk header from string pool");
+        let header = ChunkHeader::from_buff(axml_buff, ChunkType::ResStringPoolType)?;
 
         // Get remaining members
         let string_count = axml_buff.read_u32::<LittleEndian>()?;
@@ -153,8 +152,7 @@ impl StringPool {
 
                 chunk.read_to_end(&mut str_buff)?;
                 // decoded_string = String::from_utf8(str_buff)?;
-                decoded_string = String::from_utf8(str_buff)
-                                 .expect("Error: cannot decode string, using raw");
+                decoded_string = String::from_utf8(str_buff)?;
             } else {
                 str_size = axml_buff.read_u16::<LittleEndian>()? as u32;
                 // TODO: can we get rid of this unwrap here?

--- a/src/chunks/string_pool.rs
+++ b/src/chunks/string_pool.rs
@@ -7,9 +7,12 @@
 //! the size of the binary XML as there is no duplication of strings
 //! anymore.
 
-use crate::chunks::{
-    chunk_header::ChunkHeader,
-    chunk_types::ChunkType,
+use crate::{
+    chunks::{
+        chunk_header::ChunkHeader,
+        chunk_types::ChunkType,
+    },
+    errors::AxmlError
 };
 
 use std::io::{
@@ -87,7 +90,7 @@ pub struct StringPool {
 impl StringPool {
     /// Parse the string pool from the raw data
     pub fn from_buff(axml_buff: &mut Cursor<Vec<u8>>,
-                 global_strings: &mut Vec<String>) -> Self {
+                 global_strings: &mut Vec<String>) -> Result<Self, AxmlError> {
 
         // Go back 2 bytes, to account from the block type
         let initial_offset = axml_buff.position() - 2;
@@ -99,25 +102,25 @@ impl StringPool {
                      .expect("Error: cannot get chunk header from string pool");
 
         // Get remaining members
-        let string_count = axml_buff.read_u32::<LittleEndian>().unwrap();
-        let style_count = axml_buff.read_u32::<LittleEndian>().unwrap();
-        let flags = axml_buff.read_u32::<LittleEndian>().unwrap();
+        let string_count = axml_buff.read_u32::<LittleEndian>()?;
+        let style_count = axml_buff.read_u32::<LittleEndian>()?;
+        let flags = axml_buff.read_u32::<LittleEndian>()?;
         let is_sorted = (flags & (1<<0)) != 0;
         let is_utf8 = (flags & (1<<8)) != 0;
-        let strings_start = axml_buff.read_u32::<LittleEndian>().unwrap();
-        let styles_start = axml_buff.read_u32::<LittleEndian>().unwrap();
+        let strings_start = axml_buff.read_u32::<LittleEndian>()?;
+        let styles_start = axml_buff.read_u32::<LittleEndian>()?;
 
         // Get strings offsets
         let mut strings_offsets = Vec::new();
         for _ in 0..string_count {
-            let offset = axml_buff.read_u32::<LittleEndian>().unwrap();
+            let offset = axml_buff.read_u32::<LittleEndian>()?;
             strings_offsets.push(offset);
         }
 
         // Get styles offsets
         let mut styles_offsets = Vec::new();
         for _ in 0..style_count {
-            let offset = axml_buff.read_u32::<LittleEndian>().unwrap();
+            let offset = axml_buff.read_u32::<LittleEndian>()?;
             styles_offsets.push(offset);
         }
 
@@ -143,17 +146,17 @@ impl StringPool {
                 // Actually, there are two length if the file is in UTF-8: the encoded and decoded lengths
                 //
 
-                let _encoded_size = axml_buff.read_u8().unwrap() as u32;
-                str_size = axml_buff.read_u8().unwrap() as u32;
+                let _encoded_size = axml_buff.read_u8()? as u32;
+                str_size = axml_buff.read_u8()? as u32;
                 let mut str_buff = Vec::with_capacity(str_size as usize);
                 let mut chunk = axml_buff.take(str_size.into());
 
-                chunk.read_to_end(&mut str_buff).unwrap();
-                // decoded_string = String::from_utf8(str_buff).unwrap();
+                chunk.read_to_end(&mut str_buff)?;
+                // decoded_string = String::from_utf8(str_buff)?;
                 decoded_string = String::from_utf8(str_buff)
                                  .expect("Error: cannot decode string, using raw");
             } else {
-                str_size = axml_buff.read_u16::<LittleEndian>().unwrap() as u32;
+                str_size = axml_buff.read_u16::<LittleEndian>()? as u32;
                 let iter = (0..str_size as usize)
                         .map(|_| axml_buff.read_u16::<LittleEndian>().unwrap());
                 decoded_string = std::char::decode_utf16(iter).collect::<Result<String, _>>().unwrap();
@@ -169,9 +172,11 @@ impl StringPool {
             let current_start = (initial_offset + strings_start + offset) as u64;
             axml_buff.set_position(current_start);
 
-            let string_pool_ref = StringPoolRef { index: axml_buff.read_u32::<LittleEndian>().unwrap() };
-            let first_char = axml_buff.read_u32::<LittleEndian>().unwrap();
-            let last_char = axml_buff.read_u32::<LittleEndian>().unwrap();
+            let string_pool_ref = StringPoolRef {
+                index: axml_buff.read_u32::<LittleEndian>()?
+            };
+            let first_char = axml_buff.read_u32::<LittleEndian>()?;
+            let last_char = axml_buff.read_u32::<LittleEndian>()?;
 
             styles.push(StringPoolSpan {
                 name: string_pool_ref,
@@ -180,7 +185,7 @@ impl StringPool {
             });
         }
 
-        StringPool {
+        Ok(StringPool {
             header,
             string_count,
             style_count,
@@ -192,7 +197,7 @@ impl StringPool {
             styles_offsets,
             strings: global_strings.to_vec(),
             styles
-        }
+        })
     }
 }
 
@@ -280,7 +285,7 @@ mod tests {
         let mut global_strings = Vec::new();
 
         // Parse string pool from buffer
-        let string_pool = StringPool::from_buff(&mut buffer, &mut global_strings);
+        let string_pool = StringPool::from_buff(&mut buffer, &mut global_strings).unwrap();
 
         // Validate that the string pool is parsed correctly
         assert_eq!(string_pool.strings.len(), 2);
@@ -298,7 +303,7 @@ mod tests {
         let mut global_strings = Vec::new();
 
         // Parse string pool from buffer
-        let string_pool = StringPool::from_buff(&mut buffer, &mut global_strings);
+        let string_pool = StringPool::from_buff(&mut buffer, &mut global_strings).unwrap();
 
         // Validate the flags
         assert!(string_pool.is_sorted);
@@ -327,7 +332,7 @@ mod tests {
 
         let mut global_strings = Vec::new();
 
-        let string_pool = StringPool::from_buff(&mut buffer, &mut global_strings);
+        let string_pool = StringPool::from_buff(&mut buffer, &mut global_strings).unwrap();
 
         // Check that the string pool is correctly parsed and contains no strings
         assert_eq!(string_pool.strings.len(), 0);
@@ -361,7 +366,7 @@ mod tests {
 
         let mut global_strings = Vec::new();
 
-        let string_pool = StringPool::from_buff(&mut buffer, &mut global_strings);
+        let string_pool = StringPool::from_buff(&mut buffer, &mut global_strings).unwrap();
 
         // Validate that the string pool has correctly decoded the UTF-8 string
         assert_eq!(string_pool.strings.len(), 1);

--- a/src/chunks/string_pool.rs
+++ b/src/chunks/string_pool.rs
@@ -157,9 +157,10 @@ impl StringPool {
                                  .expect("Error: cannot decode string, using raw");
             } else {
                 str_size = axml_buff.read_u16::<LittleEndian>()? as u32;
+                // TODO: can we get rid of this unwrap here?
                 let iter = (0..str_size as usize)
-                        .map(|_| axml_buff.read_u16::<LittleEndian>().unwrap());
-                decoded_string = std::char::decode_utf16(iter).collect::<Result<String, _>>().unwrap();
+                    .map(|_| axml_buff.read_u16::<LittleEndian>().unwrap());
+                decoded_string = std::char::decode_utf16(iter).collect::<Result<String, _>>()?;
             }
 
             if str_size > 0 {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,25 @@
+//! Errors module
+//!
+//! This module simply enumerates the possible errors we can
+//! encounter and their associated error messages. We use
+//! `thiserror` for the heavy lifting.
+
+/*
+use std::fmt::Display;
+
+impl Display for AxmlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match AxmlErro
+    }
+}
+*/
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AxmlError {
+    #[error("reading from the cursor of bytes")]
+    CursorReadError(#[from] std::io::Error),
+    #[error("string not in the string pool")]
+    StringPoolError,
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,24 +4,18 @@
 //! encounter and their associated error messages. We use
 //! `thiserror` for the heavy lifting.
 
-/*
-use std::fmt::Display;
-
-impl Display for AxmlError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match AxmlErro
-    }
-}
-*/
-
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum AxmlError {
     #[error("reading from the cursor of bytes")]
-    CursorReadError(#[from] std::io::Error),
+    IoError(#[from] std::io::Error),
+    #[error("cannot decode string from UTF-16")]
+    StringDecodeError(#[from] std::char::DecodeUtf16Error),
     #[error("string not in the string pool")]
     StringPoolError,
     #[error("unknown namespace")]
     NamespaceError,
+    #[error("zip file error")]
+    ZipFileError(#[from] zip::result::ZipError)
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,11 +11,17 @@ pub enum AxmlError {
     #[error("reading from the cursor of bytes")]
     IoError(#[from] std::io::Error),
     #[error("cannot decode string from UTF-16")]
-    StringDecodeError(#[from] std::char::DecodeUtf16Error),
+    Utf16DecodeError(#[from] std::char::DecodeUtf16Error),
+    #[error("cannot decode string from UTF-8")]
+    Utf8StrDecodeError(#[from] std::str::Utf8Error),
+    #[error("cannot decode string from UTF-8")]
+    Utf8StringDecodeError(#[from] std::string::FromUtf8Error),
     #[error("string not in the string pool")]
     StringPoolError,
     #[error("unknown namespace")]
     NamespaceError,
-    #[error("zip file error")]
-    ZipFileError(#[from] zip::result::ZipError)
+    #[error("Zip file error")]
+    ZipFileError(#[from] zip::result::ZipError),
+    #[error("XML encoding error")]
+    XmlEncodingError(#[from] quick_xml::Error),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,4 +22,6 @@ pub enum AxmlError {
     CursorReadError(#[from] std::io::Error),
     #[error("string not in the string pool")]
     StringPoolError,
+    #[error("unknown namespace")]
+    NamespaceError,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ use std::io::{
 use std::rc::Rc;
 use std::cell::RefCell;
 
+use errors::AxmlError;
+
 use crate::chunks::{
     resource_map::ResourceMap,
     res_table::ResTable,
@@ -63,21 +65,21 @@ pub enum ComponentState {
 /// To read an AXML file directly use [`create_cursor_from_axml`] instead.
 ///
 /// [`create_cursor_from_axml`]: fn.create_cursor_from_axml.html
-pub fn create_cursor_from_apk(file_path: &str) -> Cursor<Vec<u8>> {
+pub fn create_cursor_from_apk(file_path: &str) -> Result<Cursor<Vec<u8>>, AxmlError> {
 
     let mut axml_cursor = Vec::new();
 
-    let zipfile = std::fs::File::open(file_path).unwrap();
-    let mut archive = zip::ZipArchive::new(zipfile).unwrap();
+    let zipfile = std::fs::File::open(file_path)?;
+    let mut archive = zip::ZipArchive::new(zipfile)?;
     let mut raw_file = match archive.by_name("AndroidManifest.xml") {
         Ok(file) => file,
         Err(..) => {
             panic!("Error: no AndroidManifest.xml in APK");
         }
     };
-    raw_file.read_to_end(&mut axml_cursor).expect("Error: cannot read manifest from app");
+    raw_file.read_to_end(&mut axml_cursor)?;
 
-    Cursor::new(axml_cursor)
+    Ok(Cursor::new(axml_cursor))
 }
 
 /// Open an AXML file, read the contents, and create a `Cursor` of the raw data
@@ -86,14 +88,14 @@ pub fn create_cursor_from_apk(file_path: &str) -> Cursor<Vec<u8>> {
 /// To read the manifest from an APK file use [`create_cursor_from_apk`] instead.
 ///
 /// [`create_cursor_from_apk`]: fn.create_cursor_from_apk.html
-pub fn create_cursor_from_axml(file_path: &str) -> Cursor<Vec<u8>> {
+pub fn create_cursor_from_axml(file_path: &str) -> Result<Cursor<Vec<u8>>, AxmlError> {
 
     let mut axml_cursor = Vec::new();
 
-    let mut raw_file = fs::File::open(file_path).expect("Error: cannot open AXML file");
-    raw_file.read_to_end(&mut axml_cursor).expect("Error: cannot read AXML file");
+    let mut raw_file = fs::File::open(file_path)?;
+    raw_file.read_to_end(&mut axml_cursor)?;
 
-    Cursor::new(axml_cursor)
+    Ok(Cursor::new(axml_cursor))
 }
 
 /// Parses the AXML file from a cursor.
@@ -104,11 +106,8 @@ pub fn create_cursor_from_axml(file_path: &str) -> Cursor<Vec<u8>> {
 ///
 /// [`create_cursor_from_axml`]: fn.create_cursor_from_axml.html
 /// [`create_cursor_from_apk`]: fn.create_cursor_from_apk.html
-pub fn parse_from_cursor(axml_cursor: Cursor<Vec<u8>>) -> Axml {
-    match parser::parse_xml(axml_cursor) {
-        Ok(axml) => axml,
-        Err(err) => panic!("{err}")
-    }
+pub fn parse_from_cursor(axml_cursor: Cursor<Vec<u8>>) -> Result<Axml, AxmlError> {
+    parser::parse_xml(axml_cursor)
 }
 
 /// Parses the AXML file from a string.
@@ -116,12 +115,9 @@ pub fn parse_from_cursor(axml_cursor: Cursor<Vec<u8>>) -> Axml {
 /// Given a string that represents an AXML document, parses the string into XML.
 /// This function will return an `XmlElement` which represents the root of the
 /// parsed XML document.
-pub fn parse_from_string(axml_str: &str) -> Axml {
+pub fn parse_from_string(axml_str: &str) -> Result<Axml, AxmlError> {
     let axml_cursor = Cursor::new(Vec::from(axml_str.as_bytes()));
-    match parser::parse_xml(axml_cursor) {
-        Ok(axml) => axml,
-        Err(err) => panic!("{err}")
-    }
+    parser::parse_xml(axml_cursor)
 }
 
 /// Parses the AXML from a generic reader
@@ -131,21 +127,15 @@ pub fn parse_from_string(axml_str: &str) -> Axml {
 ///
 /// [`parse_from_string`]: fn.parse_from_string.html
 /// [`Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
-pub fn parse_from_reader<R>(mut reader: R) -> Axml
+pub fn parse_from_reader<R>(mut reader: R) -> Result<Axml, AxmlError>
 where
     R: Read,
 {
-    // TODO: properly handle errors while reading
     let mut axml_vec = Vec::<u8>::new();
-    if let Err(err) = reader.read_to_end(&mut axml_vec) {
-        panic!("Error: cannot read bytes from reader: {err}");
-    }
+    reader.read_to_end(&mut axml_vec)?;
 
     let axml_cursor = Cursor::new(axml_vec);
-    match parser::parse_xml(axml_cursor) {
-        Ok(axml) => axml,
-        Err(err) => panic!("{err}")
-    }
+    parser::parse_xml(axml_cursor)
 }
 
 /// Use BFS tree traversal to get all element of a given type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod parser;
 pub mod chunks;
+pub mod errors;
 
 use std::{
     fs,
@@ -104,7 +105,10 @@ pub fn create_cursor_from_axml(file_path: &str) -> Cursor<Vec<u8>> {
 /// [`create_cursor_from_axml`]: fn.create_cursor_from_axml.html
 /// [`create_cursor_from_apk`]: fn.create_cursor_from_apk.html
 pub fn parse_from_cursor(axml_cursor: Cursor<Vec<u8>>) -> Axml {
-    parser::parse_xml(axml_cursor)
+    match parser::parse_xml(axml_cursor) {
+        Ok(axml) => axml,
+        Err(err) => panic!("{err}")
+    }
 }
 
 /// Parses the AXML file from a string.
@@ -114,7 +118,10 @@ pub fn parse_from_cursor(axml_cursor: Cursor<Vec<u8>>) -> Axml {
 /// parsed XML document.
 pub fn parse_from_string(axml_str: &str) -> Axml {
     let axml_cursor = Cursor::new(Vec::from(axml_str.as_bytes()));
-    parser::parse_xml(axml_cursor)
+    match parser::parse_xml(axml_cursor) {
+        Ok(axml) => axml,
+        Err(err) => panic!("{err}")
+    }
 }
 
 /// Parses the AXML from a generic reader
@@ -135,7 +142,10 @@ where
     }
 
     let axml_cursor = Cursor::new(axml_vec);
-    parser::parse_xml(axml_cursor)
+    match parser::parse_xml(axml_cursor) {
+        Ok(axml) => axml,
+        Err(err) => panic!("{err}")
+    }
 }
 
 /// Use BFS tree traversal to get all element of a given type

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,6 @@
 //! representing the actual XML.
 
 use std::collections::HashMap;
-use std::borrow::Cow;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::io::{
@@ -20,9 +19,7 @@ use byteorder::{
 };
 
 use quick_xml::Writer;
-use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, Event};
-use quick_xml::events::attributes::Attribute;
-use quick_xml::name::QName;
+use quick_xml::events::{BytesDecl, Event};
 
 use crate::errors::AxmlError;
 use crate::{
@@ -329,51 +326,6 @@ pub fn parse_end_element(axml_buff: &mut Cursor<Vec<u8>>,
 
     let name = strings.get(name as usize).ok_or(AxmlError::StringPoolError)?;
     Ok(name.to_string())
-}
-
-/// Handler for XML events
-pub fn handle_event<T> (writer: &mut Writer<T>,
-                        element_name: String,
-                        element_attrs: Vec<(String, String)>,
-                        namespace_prefixes: &HashMap::<String, String>,
-                        block_type: ChunkType) where T: std::io::Write {
-    match block_type {
-        ChunkType::ResXmlStartElementType => {
-            // let mut elem = BytesStart::from_content(element_name.as_bytes(), element_name.len());
-            let mut elem = BytesStart::new(&element_name);
-
-            if element_name == "manifest" {
-                for (k, v) in namespace_prefixes.iter() {
-                    if v == "android" {
-                        let mut key = String::new();
-                        key.push_str("xmlns:");
-                        key.push_str(v);
-                        let attr = Attribute {
-                            key: QName(key.as_bytes()),
-                            value: Cow::Borrowed(k.as_bytes())
-                        };
-                        elem.push_attribute(attr);
-                        break;
-                    }
-                }
-            }
-
-            for (attr_key, attr_val) in element_attrs {
-                let attr = Attribute {
-                    key: QName(attr_key.as_bytes()),
-                    value: Cow::Borrowed(attr_val.as_bytes())
-                };
-                elem.push_attribute(attr);
-            }
-
-            assert!(writer.write_event(Event::Start(elem)).is_ok());
-
-        },
-        ChunkType::ResXmlEndElementType => {
-            assert!(writer.write_event(Event::End(BytesEnd::new(element_name))).is_ok());
-        },
-        _ => println!("{:02X}, other", block_type),
-    }
 }
 
 /// Parse a whole XML document

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -345,14 +345,14 @@ pub fn parse_xml(mut axml_cursor: Cursor<Vec<u8>>) -> Result<Axml, AxmlError> {
         match block_type {
             ChunkType::ResNullType => continue,
             ChunkType::ResStringPoolType => {
-                let _ = StringPool::from_buff(&mut axml_cursor, &mut global_strings);
+                let _ = StringPool::from_buff(&mut axml_cursor, &mut global_strings)?;
             },
             ChunkType::ResTableType => {
-                ResTable::parse(&mut axml_cursor);
+                let _ = ResTable::parse(&mut axml_cursor)?;
             },
             ChunkType::ResXmlType => {
                 axml_cursor.set_position(axml_cursor.position() - 2);
-                let _ = ChunkHeader::from_buff(&mut axml_cursor, ChunkType::ResXmlType);
+                let _ = ChunkHeader::from_buff(&mut axml_cursor, ChunkType::ResXmlType)?;
             },
             ChunkType::ResXmlStartNamespaceType => {
                 parse_start_namespace(&mut axml_cursor, &global_strings, &mut namespace_prefixes)?;
@@ -378,7 +378,7 @@ pub fn parse_xml(mut axml_cursor: Cursor<Vec<u8>>) -> Result<Axml, AxmlError> {
             },
 
             ChunkType::ResXmlResourceMapType => {
-                let _ = ResourceMap::from_buff(&mut axml_cursor);
+                let _ = ResourceMap::from_buff(&mut axml_cursor)?;
             },
 
             _ => { },

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -193,8 +193,8 @@ pub fn parse_start_namespace(axml_buff: &mut Cursor<Vec<u8>>,
     let prefix = axml_buff.read_u32::<LittleEndian>()?;
     let uri = axml_buff.read_u32::<LittleEndian>()?;
 
-    let prefix_str = strings.get(prefix as usize).ok_or(AxmlError::PoolStringError)?;
-    let uri_str = strings.get(uri as usize).ok_or(AxmlError::PoolStringError)?;
+    let prefix_str = strings.get(prefix as usize).ok_or(AxmlError::StringPoolError)?;
+    let uri_str = strings.get(uri as usize).ok_or(AxmlError::StringPoolError)?;
     namespaces.insert(uri_str.to_string(), prefix_str.to_string());
 
     Ok(())
@@ -326,7 +326,7 @@ pub fn parse_end_element(axml_buff: &mut Cursor<Vec<u8>>,
     let _namespace = axml_buff.read_u32::<LittleEndian>()?;
     let name = axml_buff.read_u32::<LittleEndian>()?;
 
-    let name = strings.get(name as usize).ok_or(AxmlError::PoolStringError)?;
+    let name = strings.get(name as usize).ok_or(AxmlError::StringPoolError)?;
     Ok(name.to_string())
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -409,8 +409,7 @@ pub fn parse_xml(mut axml_cursor: Cursor<Vec<u8>>) -> Result<Axml, AxmlError> {
                 parse_end_namespace(&mut axml_cursor, &global_strings)?;
             },
             ChunkType::ResXmlStartElementType => {
-                // let (element_type, attrs) = parse_start_element(&mut axml_cursor, &global_strings, &namespace_prefixes).unwrap();
-                let element = parse_start_element(&mut axml_cursor, &global_strings, &namespace_prefixes).unwrap();
+                let element = parse_start_element(&mut axml_cursor, &global_strings, &namespace_prefixes)?;
 
                 if element.element_type == "manifest" {
                     stack.last().unwrap().borrow_mut().attributes = element.attributes.clone();
@@ -422,7 +421,7 @@ pub fn parse_xml(mut axml_cursor: Cursor<Vec<u8>>) -> Result<Axml, AxmlError> {
 
             },
             ChunkType::ResXmlEndElementType => {
-                parse_end_element(&mut axml_cursor, &global_strings).unwrap();
+                parse_end_element(&mut axml_cursor, &global_strings)?;
                 stack.pop();
             },
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -24,6 +24,7 @@ use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, Event};
 use quick_xml::events::attributes::Attribute;
 use quick_xml::name::QName;
 
+use crate::errors::AxmlError;
 use crate::{
     ResourceMap,
     StringPool,
@@ -178,7 +179,7 @@ impl Iterator for AxmlIterator {
 /// Parse the start of a namepace
 pub fn parse_start_namespace(axml_buff: &mut Cursor<Vec<u8>>,
                              strings: &[String],
-                             namespaces: &mut HashMap::<String, String>) {
+                             namespaces: &mut HashMap::<String, String>) -> Result<(), AxmlError> {
     // Go back 2 bytes, to account from the block type
     let offset = axml_buff.position();
     axml_buff.set_position(offset - 2);
@@ -187,19 +188,21 @@ pub fn parse_start_namespace(axml_buff: &mut Cursor<Vec<u8>>,
     let _header = ChunkHeader::from_buff(axml_buff, ChunkType::ResXmlStartNamespaceType)
                  .expect("Error: cannot get header from start namespace chunk");
 
-    let _line_number = axml_buff.read_u32::<LittleEndian>().unwrap();
-    let _comment = axml_buff.read_u32::<LittleEndian>().unwrap();
-    let prefix = axml_buff.read_u32::<LittleEndian>().unwrap();
-    let uri = axml_buff.read_u32::<LittleEndian>().unwrap();
+    let _line_number = axml_buff.read_u32::<LittleEndian>()?;
+    let _comment = axml_buff.read_u32::<LittleEndian>()?;
+    let prefix = axml_buff.read_u32::<LittleEndian>()?;
+    let uri = axml_buff.read_u32::<LittleEndian>()?;
 
-    let prefix_str = strings.get(prefix as usize).unwrap();
-    let uri_str = strings.get(uri as usize).unwrap();
+    let prefix_str = strings.get(prefix as usize).ok_or(AxmlError::PoolStringError)?;
+    let uri_str = strings.get(uri as usize).ok_or(AxmlError::PoolStringError)?;
     namespaces.insert(uri_str.to_string(), prefix_str.to_string());
+
+    Ok(())
 }
 
 /// Parse the end of a namepace
 pub fn parse_end_namespace(axml_buff: &mut Cursor<Vec<u8>>,
-                           _strings: &[String]) {
+                           _strings: &[String]) -> Result<(), AxmlError> {
     // Go back 2 bytes, to account from the block type
     let offset = axml_buff.position();
     axml_buff.set_position(offset - 2);
@@ -208,10 +211,12 @@ pub fn parse_end_namespace(axml_buff: &mut Cursor<Vec<u8>>,
     let _header = ChunkHeader::from_buff(axml_buff, ChunkType::ResXmlEndNamespaceType)
                  .expect("Error: cannot get header from start namespace chunk");
 
-    let _line_number = axml_buff.read_u32::<LittleEndian>().unwrap();
-    let _comment = axml_buff.read_u32::<LittleEndian>().unwrap();
-    let _prefix = axml_buff.read_u32::<LittleEndian>().unwrap();
-    let _uri = axml_buff.read_u32::<LittleEndian>().unwrap();
+    let _line_number = axml_buff.read_u32::<LittleEndian>()?;
+    let _comment = axml_buff.read_u32::<LittleEndian>()?;
+    let _prefix = axml_buff.read_u32::<LittleEndian>()?;
+    let _uri = axml_buff.read_u32::<LittleEndian>()?;
+
+    Ok(())
 }
 
 /// Parser the start of an element
@@ -307,7 +312,7 @@ pub fn parse_start_element(axml_buff: &mut Cursor<Vec<u8>>,
 
 /// Parser the end of an element
 pub fn parse_end_element(axml_buff: &mut Cursor<Vec<u8>>,
-                         strings: &[String]) -> Result<String, Error> {
+                         strings: &[String]) -> Result<String, AxmlError> {
     // Go back 2 bytes, to account from the block type
     let offset = axml_buff.position();
     axml_buff.set_position(offset - 2);
@@ -316,12 +321,13 @@ pub fn parse_end_element(axml_buff: &mut Cursor<Vec<u8>>,
     let _header = ChunkHeader::from_buff(axml_buff, ChunkType::ResXmlEndElementType)
                  .expect("Error: cannot get header from start namespace chunk");
 
-    let _line_number = axml_buff.read_u32::<LittleEndian>().unwrap();
-    let _comment = axml_buff.read_u32::<LittleEndian>().unwrap();
-    let _namespace = axml_buff.read_u32::<LittleEndian>().unwrap();
-    let name = axml_buff.read_u32::<LittleEndian>().unwrap();
+    let _line_number = axml_buff.read_u32::<LittleEndian>()?;
+    let _comment = axml_buff.read_u32::<LittleEndian>()?;
+    let _namespace = axml_buff.read_u32::<LittleEndian>()?;
+    let name = axml_buff.read_u32::<LittleEndian>()?;
 
-    Ok(strings.get(name as usize).unwrap().to_string())
+    let name = strings.get(name as usize).ok_or(AxmlError::PoolStringError)?;
+    Ok(name.to_string())
 }
 
 /// Handler for XML events
@@ -370,7 +376,7 @@ pub fn handle_event<T> (writer: &mut Writer<T>,
 }
 
 /// Parse a whole XML document
-pub fn parse_xml(mut axml_cursor: Cursor<Vec<u8>>) -> Axml {
+pub fn parse_xml(mut axml_cursor: Cursor<Vec<u8>>) -> Result<Axml, AxmlError> {
     let mut global_strings = Vec::new();
     let mut namespace_prefixes = HashMap::<String, String>::new();
 
@@ -396,10 +402,10 @@ pub fn parse_xml(mut axml_cursor: Cursor<Vec<u8>>) -> Axml {
                 let _ = ChunkHeader::from_buff(&mut axml_cursor, ChunkType::ResXmlType);
             },
             ChunkType::ResXmlStartNamespaceType => {
-                parse_start_namespace(&mut axml_cursor, &global_strings, &mut namespace_prefixes);
+                parse_start_namespace(&mut axml_cursor, &global_strings, &mut namespace_prefixes)?;
             },
             ChunkType::ResXmlEndNamespaceType => {
-                parse_end_namespace(&mut axml_cursor, &global_strings);
+                parse_end_namespace(&mut axml_cursor, &global_strings)?;
             },
             ChunkType::ResXmlStartElementType => {
                 // let (element_type, attrs) = parse_start_element(&mut axml_cursor, &global_strings, &namespace_prefixes).unwrap();
@@ -427,5 +433,5 @@ pub fn parse_xml(mut axml_cursor: Cursor<Vec<u8>>) -> Axml {
         }
     }
 
-    Axml { root }
+    Ok(Axml { root })
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -102,11 +102,10 @@ pub struct Axml {
 
 impl Axml {
     /// Write the whole parsed XML to a file
-    pub fn write_to_file(&self, file: &mut File) -> Result<(), Error> {
+    pub fn write_to_file(&self, file: &mut File) -> Result<(), AxmlError> {
         match self.to_string() {
             Ok(str_xml) => {
-                file.write_all(str_xml.as_bytes())
-                    .expect("Couldn't write to file");
+                file.write_all(str_xml.as_bytes())?;
                 Ok(())
             },
             Err(err) => { Err(err) }
@@ -114,17 +113,15 @@ impl Axml {
     }
 
     /// Convert the whole parsed XML into a string
-    pub fn to_string(&self) -> Result<String, Error> {
+    pub fn to_string(&self) -> Result<String, AxmlError> {
         let mut writer = Writer::new_with_indent(Vec::new(), b' ', 4);
 
         writer
-            .write_event(Event::Decl(BytesDecl::new("1.0", Some("utf-8"), None)))
-            .unwrap();
+            .write_event(Event::Decl(BytesDecl::new("1.0", Some("utf-8"), None)))?;
 
-        self.root.borrow().write_element(&mut writer).unwrap();
+        self.root.borrow().write_element(&mut writer)?;
 
-        let result = std::str::from_utf8(&writer.into_inner())
-            .expect("Failed to convert a slice of bytes to a string slice")
+        let result = std::str::from_utf8(&writer.into_inner())?
             .to_string();
 
         Ok(result)
@@ -182,8 +179,7 @@ pub fn parse_start_namespace(axml_buff: &mut Cursor<Vec<u8>>,
     axml_buff.set_position(offset - 2);
 
     // Parse chunk header
-    let _header = ChunkHeader::from_buff(axml_buff, ChunkType::ResXmlStartNamespaceType)
-                 .expect("Error: cannot get header from start namespace chunk");
+    let _header = ChunkHeader::from_buff(axml_buff, ChunkType::ResXmlStartNamespaceType)?;
 
     let _line_number = axml_buff.read_u32::<LittleEndian>()?;
     let _comment = axml_buff.read_u32::<LittleEndian>()?;
@@ -205,8 +201,7 @@ pub fn parse_end_namespace(axml_buff: &mut Cursor<Vec<u8>>,
     axml_buff.set_position(offset - 2);
 
     // Parse chunk header
-    let _header = ChunkHeader::from_buff(axml_buff, ChunkType::ResXmlEndNamespaceType)
-                 .expect("Error: cannot get header from start namespace chunk");
+    let _header = ChunkHeader::from_buff(axml_buff, ChunkType::ResXmlEndNamespaceType)?;
 
     let _line_number = axml_buff.read_u32::<LittleEndian>()?;
     let _comment = axml_buff.read_u32::<LittleEndian>()?;
@@ -225,8 +220,7 @@ pub fn parse_start_element(axml_buff: &mut Cursor<Vec<u8>>,
     axml_buff.set_position(offset - 2);
 
     // Parse chunk header
-    let _header = ChunkHeader::from_buff(axml_buff, ChunkType::ResXmlStartElementType)
-                 .expect("Error: cannot get header from start namespace chunk");
+    let _header = ChunkHeader::from_buff(axml_buff, ChunkType::ResXmlStartElementType)?;
 
     let _line_number = axml_buff.read_u32::<LittleEndian>()?;
     let _comment = axml_buff.read_u32::<LittleEndian>()?;
@@ -316,8 +310,7 @@ pub fn parse_end_element(axml_buff: &mut Cursor<Vec<u8>>,
     axml_buff.set_position(offset - 2);
 
     // Parse chunk header
-    let _header = ChunkHeader::from_buff(axml_buff, ChunkType::ResXmlEndElementType)
-                 .expect("Error: cannot get header from start namespace chunk");
+    let _header = ChunkHeader::from_buff(axml_buff, ChunkType::ResXmlEndElementType)?;
 
     let _line_number = axml_buff.read_u32::<LittleEndian>()?;
     let _comment = axml_buff.read_u32::<LittleEndian>()?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -222,7 +222,7 @@ pub fn parse_end_namespace(axml_buff: &mut Cursor<Vec<u8>>,
 /// Parser the start of an element
 pub fn parse_start_element(axml_buff: &mut Cursor<Vec<u8>>,
                            strings: &[String],
-                           namespace_prefixes: &HashMap::<String, String>) -> XmlElement {
+                           namespace_prefixes: &HashMap::<String, String>) -> Result<XmlElement, AxmlError> {
     // Go back 2 bytes, to account from the block type
     let offset = axml_buff.position();
     axml_buff.set_position(offset - 2);
@@ -231,40 +231,41 @@ pub fn parse_start_element(axml_buff: &mut Cursor<Vec<u8>>,
     let _header = ChunkHeader::from_buff(axml_buff, ChunkType::ResXmlStartElementType)
                  .expect("Error: cannot get header from start namespace chunk");
 
-    let _line_number = axml_buff.read_u32::<LittleEndian>().unwrap();
-    let _comment = axml_buff.read_u32::<LittleEndian>().unwrap();
-    let _namespace = axml_buff.read_u32::<LittleEndian>().unwrap();
-    let name = axml_buff.read_u32::<LittleEndian>().unwrap();
-    let _attribute_size = axml_buff.read_u32::<LittleEndian>().unwrap();
-    let attribute_count = axml_buff.read_u16::<LittleEndian>().unwrap();
-    let _id_index = axml_buff.read_u16::<LittleEndian>().unwrap();
-    let _class_index = axml_buff.read_u16::<LittleEndian>().unwrap();
-    let _style_index = axml_buff.read_u16::<LittleEndian>().unwrap();
+    let _line_number = axml_buff.read_u32::<LittleEndian>()?;
+    let _comment = axml_buff.read_u32::<LittleEndian>()?;
+    let _namespace = axml_buff.read_u32::<LittleEndian>()?;
+    let name = axml_buff.read_u32::<LittleEndian>()?;
+    let _attribute_size = axml_buff.read_u32::<LittleEndian>()?;
+    let attribute_count = axml_buff.read_u16::<LittleEndian>()?;
+    let _id_index = axml_buff.read_u16::<LittleEndian>()?;
+    let _class_index = axml_buff.read_u16::<LittleEndian>()?;
+    let _style_index = axml_buff.read_u16::<LittleEndian>()?;
 
-    let element_type = strings.get(name as usize).unwrap().to_string();
+    let element_type = strings.get(name as usize).ok_or(AxmlError::StringPoolError)?.to_string();
 
     let mut decoded_attrs = HashMap::<String, String>::new();
     for _ in 0..attribute_count {
-        let attr_namespace = axml_buff.read_u32::<LittleEndian>().unwrap();
-        let attr_name = axml_buff.read_u32::<LittleEndian>().unwrap();
-        let attr_raw_val = axml_buff.read_u32::<LittleEndian>().unwrap();
-        let data_value_type = ResValue::from_buff(axml_buff).unwrap();
+        let attr_namespace = axml_buff.read_u32::<LittleEndian>()?;
+        let attr_name = axml_buff.read_u32::<LittleEndian>()?;
+        let attr_raw_val = axml_buff.read_u32::<LittleEndian>()?;
+        let data_value_type = ResValue::from_buff(axml_buff)?;
 
         let mut decoded_attr_key = String::new();
         let mut decoded_attr_val = String::new();
 
         if attr_namespace != 0xffffffff {
-            let ns_prefix = namespace_prefixes.get(strings.get(attr_namespace as usize).unwrap()).unwrap();
+            let namespace = strings.get(attr_namespace as usize).ok_or(AxmlError::StringPoolError)?;
+            let ns_prefix = namespace_prefixes.get(namespace).ok_or(AxmlError::NamespaceError)?;
             decoded_attr_key.push_str(ns_prefix);
             decoded_attr_key.push(':');
         } else {
             // TODO
         }
 
-        decoded_attr_key.push_str(strings.get(attr_name as usize).unwrap());
+        decoded_attr_key.push_str(strings.get(attr_name as usize).ok_or(AxmlError::StringPoolError)?);
 
         if attr_raw_val != 0xffffffff {
-            decoded_attr_val.push_str(&strings.get(attr_raw_val as usize).unwrap().to_string());
+            decoded_attr_val.push_str(&strings.get(attr_raw_val as usize).ok_or(AxmlError::StringPoolError)?.to_string());
         } else {
             match data_value_type.data_type {
                 DataValueType::TypeNull => println!("TODO: DataValueType::TypeNull"),
@@ -303,11 +304,11 @@ pub fn parse_start_element(axml_buff: &mut Cursor<Vec<u8>>,
         );
     }
 
-    XmlElement {
+    Ok(XmlElement {
         element_type,
         attributes: decoded_attrs,
         children: Vec::new()
-    }
+    })
 }
 
 /// Parser the end of an element
@@ -409,7 +410,7 @@ pub fn parse_xml(mut axml_cursor: Cursor<Vec<u8>>) -> Result<Axml, AxmlError> {
             },
             ChunkType::ResXmlStartElementType => {
                 // let (element_type, attrs) = parse_start_element(&mut axml_cursor, &global_strings, &namespace_prefixes).unwrap();
-                let element = parse_start_element(&mut axml_cursor, &global_strings, &namespace_prefixes);
+                let element = parse_start_element(&mut axml_cursor, &global_strings, &namespace_prefixes).unwrap();
 
                 if element.element_type == "manifest" {
                     stack.last().unwrap().borrow_mut().attributes = element.attributes.clone();


### PR DESCRIPTION
Remove calls to `unwrap()` and use `Result` instead.