### PR TITLE
Refactor: Use PathBuf for file paths

### DIFF
--- a/src/bin/axmlparser/cli.rs
+++ b/src/bin/axmlparser/cli.rs
@@ -33,11 +33,11 @@ pub struct Args {
 pub struct Target {
    /// Path to an APK
    #[arg(short, long)]
-   apk: Option<String>,
+   apk: Option<PathBuf>,
 
    /// Path to an Android binary XML file
    #[arg(short, long)]
-   xml: Option<String>,
+   xml: Option<PathBuf>,
 
    // /// Path to resources.arsc file
    // #[arg(short, long)]
@@ -65,7 +65,7 @@ impl Args {
         panic!("Will never happen");
     }
 
-    pub fn get_arg_path(&self) -> String {
+    pub fn get_arg_path(&self) -> PathBuf {
         match self.get_arg_type() {
             ArgType::Apk  => { self.target.apk.clone().unwrap() },
             ArgType::Axml => { self.target.xml.clone().unwrap() },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod errors;
 use std::{
     fs,
     collections::HashMap,
+    path::Path,
 };
 use std::io::{
     Read,
@@ -52,7 +53,7 @@ pub enum ComponentState {
 /// assert!(rusty_axml::get_requested_permissions(&axml)
 ///                    .contains(&"android.permission.ACCESS_FINE_LOCATION".to_string()));
 /// ```
-pub fn parse_from_apk(file_path: &str) -> Result<Axml, AxmlError> {
+pub fn parse_from_apk<P: AsRef<Path>>(file_path: P) -> Result<Axml, AxmlError> {
     let cursor = create_cursor_from_apk(file_path)?;
     parse_from_cursor(cursor)
 }
@@ -68,7 +69,7 @@ pub fn parse_from_apk(file_path: &str) -> Result<Axml, AxmlError> {
 /// assert!(rusty_axml::get_requested_permissions(&axml)
 ///                    .contains(&"android.permission.ACCESS_FINE_LOCATION".to_string()));
 /// ```
-pub fn parse_from_axml(file_path: &str) -> Result<Axml, AxmlError> {
+pub fn parse_from_axml<P: AsRef<Path>>(file_path: P) -> Result<Axml, AxmlError> {
     let cursor = create_cursor_from_axml(file_path)?;
     parse_from_cursor(cursor)
 }
@@ -92,10 +93,10 @@ pub fn parse_from_axml(file_path: &str) -> Result<Axml, AxmlError> {
 /// ```
 ///
 /// [`create_cursor_from_axml`]: fn.create_cursor_from_axml.html
-pub fn create_cursor_from_apk(file_path: &str) -> Result<Cursor<Vec<u8>>, AxmlError> {
+pub fn create_cursor_from_apk<P: AsRef<Path>>(file_path: P) -> Result<Cursor<Vec<u8>>, AxmlError> {
     let mut axml_cursor = Vec::new();
 
-    let zipfile = std::fs::File::open(file_path)?;
+    let zipfile = std::fs::File::open(file_path.as_ref())?;
     let mut archive = zip::ZipArchive::new(zipfile)?;
     let mut raw_file = match archive.by_name("AndroidManifest.xml") {
         Ok(file) => file,
@@ -126,10 +127,10 @@ pub fn create_cursor_from_apk(file_path: &str) -> Result<Cursor<Vec<u8>>, AxmlEr
 /// ```
 ///
 /// [`create_cursor_from_apk`]: fn.create_cursor_from_apk.html
-pub fn create_cursor_from_axml(file_path: &str) -> Result<Cursor<Vec<u8>>, AxmlError> {
+pub fn create_cursor_from_axml<P: AsRef<Path>>(file_path: P) -> Result<Cursor<Vec<u8>>, AxmlError> {
     let mut axml_cursor = Vec::new();
 
-    let mut raw_file = fs::File::open(file_path)?;
+    let mut raw_file = fs::File::open(file_path.as_ref())?;
     raw_file.read_to_end(&mut axml_cursor)?;
 
     Ok(Cursor::new(axml_cursor))


### PR DESCRIPTION
I've replaced `String` and `&str` with `PathBuf` and `AsRef<Path>` for handling file paths in the CLI and library functions.

This change addresses issue #22 by improving cross-platform compatibility and making path handling more robust.

The following files were modified:
- `src/bin/axmlparser/cli.rs`: I changed input path types to PathBuf.
- `src/lib.rs`: I updated public functions to accept AsRef<Path> for path arguments.

All tests pass after these changes.