### PR TITLE
Fix builds on wasm targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 *.swp
 Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ required-features = ["cli"]
 cli = ["dep:clap"]
 
 [dependencies]
-byteorder = "1.4.3"
-clap = { version = "4.5.4", features = ["derive"], optional = true }
-quick-xml = "0.31.0"
-thiserror = "2.0.11"
-zip = "0.5"
+byteorder = "1.5.0"
+clap = { version= "4.5.41", features = ["derive"], optional = true }
+quick-xml = "0.38.0"
+thiserror = "2.0.12"
+zip = { version = "4.3.0", default-features=false, features=["deflate"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rusty-axml"
 version = "0.2.0"
 authors = ["Julien Gamba <julien@jgamba.eu>"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "A parser for Android AXML files"
 homepage = "https://github.com/rusty-rs/rusty-axml"

--- a/src/chunks/chunk_types.rs
+++ b/src/chunks/chunk_types.rs
@@ -74,7 +74,7 @@ impl ChunkType {
             0x0203 => ChunkType::ResTableLibraryType,
 
             /* If we find an unknown type, we stop and panic */
-            _ => panic!("Error: unknown block type {:02X}", raw_block_type)
+            _ => panic!("Error: unknown block type {raw_block_type:02X}")
         };
 
         Ok(block_type)

--- a/src/chunks/data_value_type.rs
+++ b/src/chunks/data_value_type.rs
@@ -78,7 +78,7 @@ impl DataValueType {
             0x1d => DataValueType::TypeIntColorRgb8,
             0x1e => DataValueType::TypeIntColorArgb4,
             0x1f => DataValueType::TypeIntColorRgb4,
-            _ => panic!("Error: unknown data value type {:02X}", value)
+            _ => panic!("Error: unknown data value type {value:02X}")
         }
     }
 }

--- a/src/chunks/res_table.rs
+++ b/src/chunks/res_table.rs
@@ -59,7 +59,7 @@ impl ResTable {
                 ChunkType::ResTablePackageType => {
                     ResTablePackage::parse(axml_buff)?;
                 },
-                _ => { panic!("######## Unexpected block type: {:02X}", block_type); }
+                _ => { panic!("######## Unexpected block type: {block_type:02X}"); }
             };
         }
 
@@ -123,9 +123,9 @@ impl ResTablePackage {
         let id = axml_buff.read_u32::<LittleEndian>()?;
 
         let mut name: [u16; 128] = [0; 128];
-        for i in 0..128 {
-            name[i] = axml_buff.read_u16::<LittleEndian>()?;
-            if name[i] == 0x00 {
+        for item in &mut name {
+            *item = axml_buff.read_u16::<LittleEndian>()?;
+            if *item == 0x00 {
                 break;
             }
         }

--- a/src/chunks/string_pool.rs
+++ b/src/chunks/string_pool.rs
@@ -135,24 +135,25 @@ impl StringPool {
             if is_utf8 {
                 // Read UTF-8 character count (spec calls this "UTF-16 length")
                 // This is the number of characters, not bytes.
-                let _utf8_char_count: u16; // Mark as unused for now, but read it as per spec.
                 let mut first_byte_char_count = axml_buff.read_u8()? as u16;
-                if (first_byte_char_count & 0x80) != 0 {
+
+                // Mark as unused for now, but read it as per spec.
+                let _utf8_char_count = if (first_byte_char_count & 0x80) != 0 {
                     first_byte_char_count &= 0x7F; // Mask out the high bit
-                    _utf8_char_count = (first_byte_char_count << 8) | (axml_buff.read_u8()? as u16);
+                    (first_byte_char_count << 8) | (axml_buff.read_u8()? as u16)
                 } else {
-                    _utf8_char_count = first_byte_char_count;
-                }
+                    first_byte_char_count
+                };
 
                 // Read UTF-8 byte length (spec calls this "UTF-8 length")
                 let mut first_byte_byte_len = axml_buff.read_u8()? as u16;
-                let byte_len: u16; // Renamed from _encoded_size
-                if (first_byte_byte_len & 0x80) != 0 {
+                // Renamed from _encoded_size
+                let byte_len: u16 = if (first_byte_byte_len & 0x80) != 0 {
                     first_byte_byte_len &= 0x7F; // Mask out the high bit
-                    byte_len = (first_byte_byte_len << 8) | (axml_buff.read_u8()? as u16);
+                    (first_byte_byte_len << 8) | (axml_buff.read_u8()? as u16)
                 } else {
-                    byte_len = first_byte_byte_len;
-                }
+                    first_byte_byte_len
+                };
 
                 // Use byte_len to read the string data
                 let mut str_buff = Vec::with_capacity(byte_len as usize);
@@ -164,20 +165,19 @@ impl StringPool {
                                       // TODO: According to AOSP comments for resources.arsc, UTF-8 strings might have 2 or 4 byte terminators.
                                       // This needs verification if parsing resources.arsc strings yields errors or incorrect cursor positions.
             } else { // UTF-16
-                let char_count = axml_buff.read_u16::<LittleEndian>()? as u16; // UTF-16 length in characters
-                let actual_decoded_string: String;
-                if char_count > 0 {
+                let char_count = axml_buff.read_u16::<LittleEndian>()?; // UTF-16 length in characters
+                let actual_decoded_string = if char_count > 0 {
                     let mut str_chars = Vec::with_capacity(char_count as usize);
                     for _ in 0..char_count {
                         // It's possible for a read error here if char_count is erroneously large.
                         // Consider adding error handling or further validation if issues arise.
                         str_chars.push(axml_buff.read_u16::<LittleEndian>()?);
                     }
-                    actual_decoded_string = std::char::decode_utf16(str_chars.into_iter())
-                                         .collect::<Result<String, _>>()?;
+                    std::char::decode_utf16(str_chars.into_iter())
+                                         .collect::<Result<String, _>>()?
                 } else {
-                    actual_decoded_string = String::new();
-                }
+                    String::new()
+                };
                 axml_buff.read_u16::<LittleEndian>()?; // Consume UTF-16 null terminator (0x0000)
                 decoded_string = actual_decoded_string;
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -66,7 +66,7 @@ impl XmlElement {
             element.write_empty().unwrap();
         } else {
             element
-                .write_inner_content(|writer| -> Result<(), quick_xml::Error> {
+                .write_inner_content(|writer| -> Result<(), Error> {
                     for child in self.children.iter() {
                         child.as_ref().borrow().write_element(writer).unwrap();
                     }


### PR DESCRIPTION
This fixes builds for the `wasm32-unknown-unknown` target by removing the unused features from the zip dependency (specifically `bzip2` is the unsupported one)

I've also bumped the dependency versions as some of them are ~4 years old, cleaned up outstanding clippy lints and updated to the 2024 language standard. Feel free to drop any of those last two commits if you've got an unwritten reason for not doing them (e.g. MSRV).